### PR TITLE
Support generation of jmp thunk table

### DIFF
--- a/cmdline.ml
+++ b/cmdline.ml
@@ -42,6 +42,7 @@ let cygpath_arg : [`Yes | `No | `None] ref = ref `None
 let implib = ref false
 let deffile = ref None
 let stack_reserve = ref None
+let use_jmptbl = ref None
 
 let usage_msg =
   Printf.sprintf
@@ -172,6 +173,12 @@ let specs = [
 
   "-nodefaultlibs", Arg.Clear use_default_libs,
   " Do not assume any default library";
+
+  "-nojmptbl", Arg.Unit (fun () -> use_jmptbl := Some false),
+  " Do not use jmp thunk table (default for 32-bit target) ";
+
+  "-jmptbl", Arg.Unit (fun () -> use_jmptbl := Some true),
+  " Use jmp thunk table (default for 64-bit target)";
 
   "-builtin", Arg.Set builtin_linker,
   " Use built-in linker to produce a dll";


### PR DESCRIPTION
As I said, I have created a patch to support generation of jmp thunk table. Its purpose is to avoid "target is too far" error on 64-bit platforms. Though, for universality I made it able to be utilized in 32-bit platforms as well.
I wanted to let you know that this is actually possible.

There is one minor flaw that is it will put unneeded symbols in the jmp thunk table. This will increase the size of the binary but that amount is negligible. This can be fixed later.

I suppose this also well accomodates with COMDAT. Because there arise no need to modify the object files at all. But I have not yet tested it.

So, what would you say?
