### PR TITLE
Include version number in source tarball directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,13 +162,13 @@ URL = frisch@frisch.fr:www/flexdll/
 PACKAGE = flexdll-$(VERSION).tar.gz
 
 package_src:
-	rm -Rf flexdll
-	mkdir flexdll
-	mkdir flexdll/test
-	cp -a *.ml Makefile $(COMMON_FILES) version.rc flexdll/
-	cp -aR test/Makefile test/*.c flexdll/test/
-	tar czf $(PACKAGE) flexdll
-	rm -Rf flexdll
+	rm -Rf flexdll-$(VERSION)
+	mkdir flexdll-$(VERSION)
+	mkdir flexdll-$(VERSION)/test
+	cp -a *.ml Makefile $(COMMON_FILES) version.rc flexdll-$(VERSION)/
+	cp -aR test/Makefile test/*.c flexdll-$(VERSION)/test/
+	tar czf $(PACKAGE) flexdll-$(VERSION)
+	rm -Rf flexdll-$(VERSION)
 
 upload:
 	rsync $(PACKAGE) CHANGES LICENSE $(URL)


### PR DESCRIPTION
Is there a reason why you use `flexdll` rather than `flexdll-$(VERSION)` in the `package_src` target in the Makefile, given that the tarball is named flexdll-$(VERSION).tar.gz?
Of the large number of tarballs I extract for my OCaml installation, flexdll is the only one which doesn't include its version in the resulting folder (i.e. matching the tarball)
I _personally_ prefer the version number convention as I sometimes end up wanting multiple versions of a library in the same directory (for whatever reason)