### PR TITLE
Do not read aux section when COMDAT selection number is not 5

### DIFF
--- a/coff.ml
+++ b/coff.ml
@@ -707,7 +707,8 @@ module Coff = struct
 	    | { storage = 3; stype = 0; auxn = auxn } when auxn > 0 ->
 		(* section def *)
 		let num = int16 s.auxs 12 in
-		if num > 0 then
+                let sel = int8 s.auxs 14 in
+		if sel = 5 && num > 0 then
 		  (try s.extra_info <- `Section sections.(num - 1)
 		   with Invalid_argument _ ->
 		     Printf.eprintf "** section %i / %i (%s)\n" num


### PR DESCRIPTION
The aux parameter 12 is unused when the parameter 14 is not 5 according to the [documentation section 5.5.5, page 52](http://www.skyfree.org/linux/references/coff.pdf). This will allow linking of coff files generated by clang-cl.