### PR TITLE
Allow FlexDLL to build using 64-bit Windows SDK

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+findwinsdk text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.swp
+*.obj
+*.o
+*.cmx
+*.cmi
+*.dll
+flexlink.exe
+test/dump.exe
+version.res
+version.ml
+Makefile.winsdk

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ demo_msvc64:  flexlink.exe flexdll_msvc64.obj flexdll_initer_msvc64.obj
 	(cd test && $(MSVC64_PREFIX) $(MAKE) clean demo CHAIN=msvc64 CC="$(MSVCC64)" O=obj)
 
 clean:
-	rm -f *.obj *.o *.lib *.a *.exe *.cmx *.dll *.exp *.cmi *~
+	rm -f *.obj *.o *.lib *.a *.exe *.cmx *.dll *.exp *.cmi *~ version.res version.ml
 	cd test && $(MAKE) clean
 
 

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,14 @@ OCAMLOPT = ocamlopt
 
 ifeq ($(TOOLCHAIN), msvc)
 RES=version.res
+ifeq ($(ARCH), i386)
+RES_PREFIX=$(MSVC_PREFIX)
+else
+RES_PREFIX=$(MSVC64_PREFIX)
+endif
 else
 RES=version_res.o
+RES_PREFIX=
 endif
 
 ifeq ($(NATDYNLINK), false)
@@ -103,10 +109,10 @@ OBJS = version.ml coff.ml cmdline.ml create_dll.ml reloc.ml
 flexlink.exe: $(OBJS) $(RES)
 	@echo Building flexlink.exe with TOOLCHAIN=$(TOOLCHAIN)
 	rm -f flexlink.exe
-	$(OCAMLOPT) -g -w -105 -o flexlink.exe $(LINKFLAGS) $(OBJS)
+	$(RES_PREFIX) $(OCAMLOPT) -g -w -105 -o flexlink.exe $(LINKFLAGS) $(OBJS)
 
 version.res: version.rc
-	rc version.rc
+	$(RES_PREFIX) rc version.rc
 
 version_res.o: version.rc
 	$(TOOLPREF)windres version.rc version_res.o

--- a/findwinsdk
+++ b/findwinsdk
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+SDK=
+SDK_INC=
+SDK_LIB=
+
+SDK_ROOT=$(reg query "HKLM\SOFTWARE\Microsoft\Microsoft SDKs\Windows" /v CurrentInstallFolder 2>/dev/null | fgrep REG_SZ | sed -e "s/.*REG_SZ *//" | cygpath -f - -md)
+
+if [ "$SDK_ROOT" != "" ] ; then
+  SETENV=$(cygpath $SDK_ROOT)/Bin
+  
+  if [ -e "$SETENV" ] ; then
+    num=0
+    while IFS= read -r line; do
+      case $num in
+        0)
+          SDK=${line%% };;
+        1)
+          SDK_LIB=${line%% };;
+        2)
+          SDK_INC=${line%% };;
+      esac
+      ((num++))
+    done < <(PROCESSOR_ARCHITEW6432=$1 PROCESSOR_ARCHITECTURE=$1 INCLUDE= LIB= PATH="$SETENV:$PATH" C:/Windows/system32/cmd.exe /v:on /c 'SetEnv.cmd /release && echo XMARKER && echo !PATH! && echo !LIB! && echo !INCLUDE!' 2>/dev/null | fgrep "XMARKER" -A 3 | tail -3)
+
+    SDK=$(cygpath "$SDK" -p)
+    SDK=${SDK%:$PATH}
+
+    SDK_LIB=${SDK_LIB%%;}
+    SDK_INC=${SDK_INC%%;}
+
+  fi
+fi
+
+echo SDK$2:="$SDK"
+echo SDK$2_INC:="$SDK_INC"
+echo SDK$2_LIB:="$SDK_LIB"

--- a/version.rc
+++ b/version.rc
@@ -1,4 +1,5 @@
-#include "afxres.h"
+//#include "afxres.h"
+#include <windows.h>
 
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)


### PR DESCRIPTION
Detection code for the Microsoft C compilers assumes (with comment!) that the 32-bit version is installed.

Rather than hacking that code to fallback and try to detect the 64-bit version, this patch attempts to query the actually installation of the Windows SDK and tries to locate its SetEnv script. It then calls SetEnv in a way which allows it to extract the PATH, LIB and INCLUDE changes that it would make (this is relatively easy because SetEnv only updates the start of the environment variables).

These are then used to allow FlexDLL's Makefile to set PATH in the same way as it sets LIB and INCLUDE before calling cl, but it removes some of the "guesswork". The old detection code is left in place for installations using Visual Studio rather than the WinSDK (I'm afraid I'm a bit too lazy to set a snapshot machine up just to test Visual Studio 2008)

The patch allows flexlink.exe to be built very liberally - i.e. in an environment where ocamlopt wouldn't normally work because of a lack of ml.exe/ml64.exe.

I've also "fixed" version.rc to include <windows.h> rather than the older afxres.h as the standard Windows SDK (and I believe express versions of Visual Studio?) don't include MFC support files.

Tested in various configurations - the mingw builds of flexlink.exe and their support files still work and, on a machine with the MSVC build of OCaml in PATH, but not ml.exe, it is possible to run:
make CHAINS="msvc msvc64" support flexlink.exe
and it correctly determines which C compiler to select based on OCaml's Makefile.config
The test suite also seems to be working.