### PR TITLE
Add build compatibility for 3.11.0--4.02.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ test/dump.exe
 version.res
 version.ml
 Makefile.winsdk
+COMPILER-*
+Compat.ml

--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@ Next version
 - Ignore "-g" (passed by OCaml when building ocamlrund) (patch by whitequark)
 - Uses gcc -print-search-dirs instead of gcc -print-sysroot when figuring out the default
   library search paths (patch by whitequark)
-- Modernize code for OCaml 4.03
+- Modernize code for OCaml 4.03 (patch for compatibility layers for earlier versions by David Allsopp)
 - Better support for long command line when calling the toolchain linker
 - Do not perform relocation from the DLL entry point when the DLL is loaded in "not for
   execution mode" (http://caml.inria.fr/mantis/view.php?id=7268)

--- a/Compat402.ml
+++ b/Compat402.ml
@@ -1,0 +1,29 @@
+(************************************************************************)
+(*   FlexDLL                                                            *)
+(*   Alain Frisch                                                       *)
+(*                                                                      *)
+(*   Copyright 2007 Institut National de Recherche en Informatique et   *)
+(*   en Automatique.                                                    *)
+(************************************************************************)
+
+(* Back-port required functionality from Bytes in 4.02.0 *)
+type bytes = string
+module Bytes = struct
+  include String
+
+  let blit_string = blit
+  let sub_string = sub
+  let of_string x = x
+  let to_string x = x
+  let cat = (^)
+end
+let output_bytes = output_string
+
+module Buffer = struct
+  include Buffer
+
+  let to_bytes = contents
+end
+
+(* Introduced in 4.01.0 *)
+let ( |> ) x f = f x

--- a/Compat403.ml
+++ b/Compat403.ml
@@ -1,0 +1,40 @@
+(************************************************************************)
+(*   FlexDLL                                                            *)
+(*   Alain Frisch                                                       *)
+(*                                                                      *)
+(*   Copyright 2007 Institut National de Recherche en Informatique et   *)
+(*   en Automatique.                                                    *)
+(************************************************************************)
+
+module Char = struct
+  include Char
+
+  (* Taken from 4.03.0 *)
+  let lowercase_ascii c =
+    if (c >= 'A' && c <= 'Z')
+    then unsafe_chr(code c + 32)
+    else c
+
+  let uppercase_ascii c =
+    if (c >= 'a' && c <= 'z')
+    then unsafe_chr(code c - 32)
+    else c
+end
+
+module String = struct
+  include String
+
+  let (lowercase_ascii, uppercase_ascii) =
+    (* Taken from 4.03.0 (not available before 4.00.0) *)
+    let map f s =
+      let l = length s in
+        if l = 0 then s else begin
+          (* create and unsafe_set trigger an irrelevant deprecation warning on 4.02.x *)
+          let r = create l in
+          for i = 0 to l - 1 do unsafe_set r i (f (unsafe_get s i)) done;
+          r
+        end
+    in
+      (map Char.lowercase_ascii, map Char.uppercase_ascii)
+end
+

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -51,7 +51,7 @@ let usage_msg =
     Version.version
 
 let footer =
-{|Notes:
+"Notes:
 * The -I, -l and -L options do not need to be separated from their argument.
 * An option like /linkXXX is an abbrevation for '-link XXX'.
 * FlexDLL's object files are searched by default in the same directory as
@@ -59,7 +59,7 @@ let footer =
   if it is defined.
 * Extra argument can be passed in the environment variable FLEXLINKFLAGS.
 
-Homepage: http://alain.frisch.fr/flexdll.html|}
+Homepage: http://alain.frisch.fr/flexdll.html"
 
 let specs = [
   "-o", Arg.Set_string output_file,

--- a/coff.ml
+++ b/coff.ml
@@ -9,6 +9,8 @@
 (* This module implements a reader/writer for COFF object files
    and libraries. *)
 
+include Compat
+
 module Buf : sig
   type t
   val create: unit -> t


### PR DESCRIPTION
Apropos of #20, this commit adds complete build compatibility for 3.11.0 onwards. My opinion - which I expect matches yours - is that this can be kept until such point as a language feature is used where back-porting becomes non-trivial, and then it can be completely removed.

The code in `StringCompat.ml` is lifted straight out of OCaml 4.03.0 (I'm assuming licence compatibility/permission to do that?)

`Makefile` tests ocamlopt -version each time and uses a cookie to detect changes in the compiler (for example, if using opam to switch between multiple compilers...) and regenerates the files.

I've tested it with 3.11.0, 4.02.3 and 4.03.0 - it'll get a bit more battle testing shortly!