### PR TITLE
Remove warnings from format strings.

### DIFF
--- a/flexdll.c
+++ b/flexdll.c
@@ -125,9 +125,9 @@ static void dump_reloctbl(reloctbl *tbl) {
 
   for (ptr = tbl->entries; ptr->kind; ptr++)
     printf(" %p (kind:%04lx) (now:%p)  %s\n",
-	   ptr->addr,
-	   ptr->kind,
-	   *((uintnat*) ptr->addr),
+	   (void *)ptr->addr,
+	   (unsigned long)ptr->kind,
+	   (void *)((UINT_PTR)(*((uintnat*) ptr->addr))),
 	   ptr->name
 	   );
 }
@@ -208,7 +208,7 @@ static void relocate(resolver f, void *data, reloctbl *tbl) {
       s -= (INT_PTR)(ptr -> addr) + 4;
       s += *((INT32*) ptr -> addr);
       if (s != (INT32) s) {
-        sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32, target is too far: %p  %p", s, (INT32) s);
+        sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32, target is too far: %p  %p", (void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
         error = 3;
         return;
       }
@@ -218,7 +218,7 @@ static void relocate(resolver f, void *data, reloctbl *tbl) {
       s -= (INT_PTR)(ptr -> addr) + 8;
       s += *((INT32*) ptr -> addr);
       if (s != (INT32) s) {
-        sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32_4, target is too far: %p  %p", s, (INT32) s);
+        sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32_4, target is too far: %p  %p",(void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
         error = 3;
         return;
       }
@@ -228,7 +228,7 @@ static void relocate(resolver f, void *data, reloctbl *tbl) {
       s -= (INT_PTR)(ptr -> addr) + 5;
       s += *((INT32*) ptr -> addr);
       if (s != (INT32) s) {
-        sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32_1, target is too far: %p  %p", s, (INT32) s);
+        sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32_1, target is too far: %p  %p",(void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
         error = 3;
         return;
       }
@@ -238,7 +238,7 @@ static void relocate(resolver f, void *data, reloctbl *tbl) {
       s -= (INT_PTR)(ptr -> addr) + 6;
       s += *((INT32*) ptr -> addr);
       if (s != (INT32) s) {
-        sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32_2, target is too far: %p  %p", s, (INT32) s);
+        sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32_2, target is too far: %p  %p",(void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
         error = 3;
         return;
       }
@@ -273,7 +273,7 @@ static void dump_symtbl(symtbl *tbl)
   int i;
 
   if (!tbl) { printf("No symbol table\n"); return; }
-  printf("Dynamic symbol at %p (size = %i)\n", tbl, tbl->size); fflush(stdout);
+  printf("Dynamic symbol at %p (size = %u)\n", tbl, (unsigned int) tbl->size); fflush(stdout);
 
   for (i = 0; i < tbl->size; i++) {
     printf("[%i] ", i); fflush(stdout);


### PR DESCRIPTION
MSVC emits some warnings for wrong format strings. Adding a few
appropriate casts avoids them.