### PR TITLE
Ensure bootstrapping picks up correct version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION = 0.35
 all: flexlink.exe support
 
 include $(shell cygpath -ad "$(shell ocamlopt -where)/Makefile.config")
-OCAML_VERSION:=$(shell ocamlopt -version|sed -e "s/+.*//" -e "s/\.//g")
+OCAML_VERSION:=$(shell $(OCAMLOPT) -version|sed -e "s/+.*//" -e "s/\.//g")
 
 MINGW_PREFIX = i686-w64-mingw32-
 MINCC = $(MINGW_PREFIX)gcc


### PR DESCRIPTION
Calling ocamlopt directly could pick up a system-installed ocamlopt, and
so select the wrong version of the compiler.