### PR TITLE
Fix sources tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ package_src:
 	rm -Rf flexdll-$(VERSION)
 	mkdir flexdll-$(VERSION)
 	mkdir flexdll-$(VERSION)/test
-	cp -a $(filter-out Compat.ml version.ml,$(OBJS) $(shell git ls-files Compat*.ml)) Makefile $(COMMON_FILES) version.rc flexdll-$(VERSION)/
+	cp -a $(filter-out Compat.ml version.ml,$(OBJS) $(shell git ls-files Compat*.ml)) Makefile findwinsdk $(COMMON_FILES) version.rc flexdll-$(VERSION)/
 	cp -aR test/Makefile test/*.c flexdll-$(VERSION)/test/
 	tar czf $(PACKAGE) flexdll-$(VERSION)
 	rm -Rf flexdll-$(VERSION)


### PR DESCRIPTION
There is a mistake in `Makefile` from when my findwinsdk script was added - it needs to be included in the sources tarball.

This patch fixes Makefile for future versions - please could you regenerate the .tar.gz file on your website for 0.35 (or just add the findwinsdk script to it)?