### PR TITLE
bootstrapping support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 VERSION = 0.35
 all: flexlink.exe support
 
-include $(shell cygpath -ad "$(shell ocamlopt -where)/Makefile.config")
+OCAML_CONFIG_FILE=$(shell cygpath -ad "$(shell ocamlopt -where)/Makefile.config")
+include $(OCAML_CONFIG_FILE)
 OCAMLOPT=ocamlopt
 OCAML_VERSION:=$(shell $(OCAMLOPT) -version|sed -e "s/+.*//" -e "s/\.//g")
 ifeq ($(OCAML_VERSION),)


### PR DESCRIPTION
Get the OCaml config file name through an intermediate variable. Then the caller can override it if necessary. This will let us avoid nasty error messages during the bootstrapping build called by OCaml's makefile.
