### PR TITLE
Added -arg,-arg0 functions like in ocaml.

### DIFF
--- a/Compat405.ml
+++ b/Compat405.ml
@@ -1,0 +1,48 @@
+(************************************************************************)
+(*   FlexDLL                                                            *)
+(*   Alain Frisch                                                       *)
+(*                                                                      *)
+(*   Copyright 2007 Institut National de Recherche en Informatique et   *)
+(*   en Automatique.                                                    *)
+(************************************************************************)
+
+module Arg = struct
+  include Arg
+
+  let trim_cr s =
+    let len = String.length s in
+    if len > 0 && String.get s (len - 1) = '\r' then
+      String.sub s 0 (len - 1)
+    else
+    s
+  (* Taken from 4.05.0 (not available before 4.05.0) *)
+  let read_aux trim sep file =
+  let ic = open_in_bin file in
+  let buf = Buffer.create 200 in
+  let words = ref [] in
+  let stash () =
+    let word =  (Buffer.contents buf) in
+    let word = if trim then trim_cr word else word in
+    words := word :: !words;
+    Buffer.clear buf
+  in
+  let rec read () =
+    try
+      let c = input_char ic in
+      if c = sep then begin
+        stash (); read ()
+      end else begin
+        Buffer.add_char buf c; read ()
+      end
+    with End_of_file ->
+      if Buffer.length buf > 0 then
+        stash () in
+  read ();
+  close_in ic;
+  Array.of_list (List.rev !words)
+
+  let read_arg = read_aux true '\n'
+
+  let read_arg0 = read_aux false '\x00'
+
+end

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ COMPILER-$(OCAML_VERSION):
 
 test_ver = $(shell if [ $(OCAML_VERSION) -lt $(1) ] ; then echo lt ; fi)
 
-Compat.ml: COMPILER-$(OCAML_VERSION) $(if $(call test_ver,4030),Compat403.ml) $(if $(call test_ver,4020),Compat402.ml)
+Compat.ml: COMPILER-$(OCAML_VERSION) $(if $(call test_ver,4050),Compat405.ml) $(if $(call test_ver,4030),Compat403.ml) $(if $(call test_ver,4020),Compat402.ml)
 	cat $^ > $@
 
 flexlink.exe: $(OBJS) $(RES)

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -6,6 +6,8 @@
 (*   en Automatique.                                                    *)
 (************************************************************************)
 
+include Compat
+
 let underscore = ref true
     (* Are "normal" symbols prefixed with an underscore? *)
 
@@ -62,6 +64,7 @@ let footer =
 Homepage: http://alain.frisch.fr/flexdll.html"
 
 let specs = [
+
   "-o", Arg.Set_string output_file,
   " Choose the name of the output file";
 
@@ -245,6 +248,10 @@ let parse_cmdline () =
         String.sub s 0 2 :: String.sub s 2 (String.length s - 2) :: tr rest
     | s :: rest when String.length s >= 5 && String.sub s 0 5 = "/link" ->
         "-link" :: String.sub s 5 (String.length s - 5) :: tr rest
+    | "-arg" :: x :: rest ->
+        tr (Array.to_list (read_arg x)) @ rest
+    | "-arg0" :: x :: rest ->
+        tr (Array.to_list (read_arg0 x)) @ rest
     | x :: rest when x <> "" && x.[0] = '-' ->
         begin
           try


### PR DESCRIPTION
This allows the usage of -arg and -arg0 like for the ocaml compiler.

I will also submit a PR against ocaml such that the ocaml compiler prints the arguments using `write_arg0`.