### PR TITLE
On MSVC, link libfoo.lib or foo.lib for -lfoo

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Next Version
 - Add Unicode support (patch by Nicolás Ojeda Bär)
 - Workaround apparent bug in VS 2017.3 link (patch by David Allsopp)
+- Additional heuristic for -lfoo on MSVC: try libfoo.lib but then try foo.lib (David Allsopp)
 
 Version 0.35
 - Fixes for clang (patch by Roven Gabriel)


### PR DESCRIPTION
This is related to https://github.com/ocaml/ocaml/pull/1189, please see the full description of the motivation there!