### PR TITLE
Add AppVeyor script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+platform:
+  - x64
+
+image: Visual Studio 2015
+
+environment:
+  global:
+    CYG_ROOT: C:/cygwin
+    CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
+    CYG_CACHE: C:/cygwin/var/cache/setup
+    FLEXDLL_DIR: C:/flexdll
+  matrix:
+#    - OCAMLBRANCH: 4.02
+    - OCAMLBRANCH: 4.03
+    - OCAMLBRANCH: 4.04
+    - OCAMLBRANCH: 4.05
+    - OCAMLBRANCH: trunk
+  OCAMLROOT: C:/OCaml
+
+cache:
+  - C:/OCaml
+
+install:
+  - mkdir "%FLEXDLL_DIR%"
+  - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-bin-0.35.zip" -FileName "flexdll.zip"
+  - appveyor DownloadFile "http://alain.frisch.fr/flexdll/flexdll-0.35.tar.gz" -FileName "flexdll.tar.gz"
+  - cinst 7zip.commandline
+  - mkdir flexdll-tmp
+  - cd flexdll-tmp
+  - 7za x -y ..\flexdll.zip
+  - for %%F in (flexdll.h flexlink.exe default_amd64.manifest) do copy %%F "%FLEXDLL_DIR%"
+  - cd ..
+  # Make sure the Cygwin path comes before the Git one (otherwise
+  # cygpath behaves crazily), but after the MSVC one.
+  - set Path=C:\cygwin\bin;%OCAMLROOT%\bin;C:\flexdll;%Path%
+  - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
+  - '"%CYG_ROOT%\setup-x86.exe" -qgnNdO -R "%CYG_ROOT%" -s "%CYG_MIRROR%" -l "%CYG_CACHE%" -P diffutils -P gcc-core -P cygwin64-gcc-core -P mingw64-i686-gcc-core -P mingw64-x86_64-gcc-core -P make >NUL'
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+  - appveyor DownloadFile "https://raw.githubusercontent.com/ocaml/ocaml/trunk/tools/msvs-promote-path" -FileName "msvs-promote-path"
+
+build_script:
+  - "%CYG_ROOT%/bin/bash -lc \"echo 'eval $($APPVEYOR_BUILD_FOLDER/msvs-promote-path)' >> ~/.bash_profile\""
+  - '%CYG_ROOT%/bin/bash -lc "$APPVEYOR_BUILD_FOLDER/appveyor_build.sh"'
+
+test: off

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+function run {
+    NAME=$1
+    shift
+    echo "-=-=- $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+    "$@"
+    CODE=$?
+    if [ $CODE -ne 0 ]; then
+        echo "-=-=- $NAME failed! -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+        exit $CODE
+    else
+        echo "-=-=- End of $NAME -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-"
+    fi
+}
+
+echo ** OCAMLROOT=$OCAMLROOT
+
+cd $APPVEYOR_BUILD_FOLDER
+
+tar -xzf flexdll.tar.gz
+cd flexdll-0.35
+make MSVC_DETECT=0 CHAINS=msvc64 support
+cp flexdll*_msvc64.obj "$FLEXDLL_DIR"
+cd ..
+
+# Do not perform end-of-line conversion
+git config --global core.autocrlf false
+git clone https://github.com/ocaml/ocaml.git --branch $OCAMLBRANCH --depth 1 ocaml
+
+cd ocaml
+
+MAKEOCAML=make
+CONFIG_DIR=byterun/caml
+
+case $OCAMLBRANCH in
+    4.01|4.02|4.03|4.04|4.05)
+        MAKEOCAML="make -f Makefile.nt"
+        CONFIG_DIR=config
+        ;;
+esac
+
+if [ ! -f $OCAMLROOT/STAMP ] || [ "$(git rev-parse HEAD)" != "$(cat $OCAMLROOT/STAMP)" ]; then
+    cp config/m-nt.h $CONFIG_DIR/m.h
+    cp config/s-nt.h $CONFIG_DIR/s.h
+    #cp config/Makefile.msvc config/Makefile
+    cp config/Makefile.msvc64 config/Makefile
+
+    cp config/Makefile config/Makefile.bak
+    sed -e "s|PREFIX=.*|PREFIX=$OCAMLROOT|" \
+        -e "s|OTHERLIBRARIES=.*|OTHERLIBRARIES=|" \
+        -e "s|WITH_DEBUGGER=.*|WITH_DEBUGGER=|" \
+        -e "s|WITH_OCAMLDOC=.*|WITH_OCAMLDOC=|" \
+        config/Makefile.bak > config/Makefile
+    #run "Content of config/Makefile" cat config/Makefile
+
+    run "make world" $MAKEOCAML world
+    run "make opt" $MAKEOCAML opt
+    run "make install" $MAKEOCAML install
+
+    git rev-parse HEAD > $OCAMLROOT/STAMP
+fi
+
+export CAML_LD_LIBRARY_PATH=$OCAMLROOT/lib/stublibs
+
+cd $APPVEYOR_BUILD_FOLDER
+
+run "make flexlink.exe" make MSVC_DETECT=0 flexlink.exe
+
+CHAINS="mingw mingw64 cygwin cygwin64 msvc msvc64"
+
+for CHAIN in $CHAINS; do
+    run "make build_$CHAIN" make build_$CHAIN
+done
+
+for CHAIN in $CHAINS; do
+    run "make demo_$CHAIN" make demo_$CHAIN
+done

--- a/clear_appveyor_cache.sh
+++ b/clear_appveyor_cache.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if [ $# -ne 2 ]; then
+    echo Usage: $0 REPO TOKEN
+    exit 1
+fi
+
+curl -X DELETE https://ci.appveyor.com/api/projects/$1/buildcache \
+     -H "Authorization: Bearer $2" \
+     -H "Content-Type: application/json"


### PR DESCRIPTION
What it does:

1. Compiles OCaml using the `msvc64` toolchain and a precompiled binary of `flexdll 0.34`.
2. Compiles `flexlink.exe` using this OCaml and the support C code with the six supported toolchains.
3. It builds & runs the demo code again with the six supported toolchains.

The OCaml versions tested are `4.02`, `4.03`, and `4.04`.  The binaries are cached so that there is no need to recompile each time.  We need to add `4.05` but need to tweak the build instructions (no more `Makefile.nt`).

Should we be testing `4.01` as well ?

When/if this is merged you will need to connect the repository to AppVeyor to get things started.