### PR TITLE
Workaround apparent bug in VS 2017.3 link

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Next Version
 - Add Unicode support (patch by Nicolás Ojeda Bär)
+- Workaround apparent bug in VS 2017.3 link (patch by David Allsopp)
 
 Version 0.35
 - Fixes for clang (patch by Roven Gabriel)

--- a/reloc.ml
+++ b/reloc.ml
@@ -986,6 +986,9 @@ let build_dll link_exe output_file files exts extra_args =
           else
             temp_file "dyndll_implib" ".lib"
         in
+        (* VS 2017.3 doesn't seem to be able to cope with /implib: existing but
+           being an empty file. *)
+        let c = open_out implib in output_string c "x"; close_out c;
         let _impexp = add_temp (Filename.chop_suffix implib ".lib" ^ ".exp") in
         let extra_args =
           if !custom_crt then "/nodefaultlib:LIBCMT /nodefaultlib:MSVCRT " ^ extra_args


### PR DESCRIPTION
This is very weird - I can't see any in the VS 2017.3 release notes to suggest this change to the linker, but the error reported in #39 can be triggered by empty files, so I tried writing a single byte and the problem disappears!

I believe that the only reason that the implib is specified is so that flexlink can delete the .lib and .exp file cleanly, there are three other solutions:
 1. Sandbox the entire link command in a sub-directory of tmp and erase everything in it at the end (tedious amount of code...)
 2. Create the .exp file instead using `temp_file` and generate the .lib name from that (the linker doesn't seem to care about the .exp file existing)
 3. Create another file entirely and generate the .lib name from that

But I stopped at this solution, as it worked!