### PR TITLE
"flexlink -install" to compile its own runtime objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ package_bin:
 	$(MAKE) clean all
 	rm -f $(PACKAGE_BIN)
 	zip $(PACKAGE_BIN) $(COMMON_FILES) \
-	    flexlink.exe flexdll_*.obj flexdll_*.o
+	    flexlink.exe flexdll_*.obj flexdll_*.o flexdll.c flexdll_initer.c
 
 do_upload_bin:
 	rsync $(PACKAGE_BIN) $(URL)
@@ -268,7 +268,7 @@ PREFIX = "C:\Program Files (x86)\flexdll"
 
 install:
 	mkdir -p $(PREFIX)
-	cp $(COMMON_FILES) flexlink.exe flexdll_*.obj flexdll_*.o $(PREFIX)
+	cp $(COMMON_FILES) flexlink.exe flexdll_*.obj flexdll_*.o flexdll.c flexdll_initer.c $(PREFIX)
 
 installer:
 	rm -rf flexdll_install_files

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ version.ml: Makefile
 	echo "let version = \"$(VERSION)\"" > version.ml
 	echo "let mingw_prefix = \"$(MINGW_PREFIX)\"" >> version.ml
 	echo "let mingw64_prefix = \"$(MINGW64_PREFIX)\"" >> version.ml
+	echo "let cygwin_prefix = \"$(CYGWIN_PREFIX)\"" >> version.ml
+	echo "let cygwin64_prefix = \"$(CYGWIN64_PREFIX)\"" >> version.ml
 
 # Supported tool-chains
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ MSVC_PREFIX=
 MSVC64_PREFIX=
 MSVCC=cl.exe $(MSVC_FLAGS)
 MSVCC64=cl.exe $(MSVC_FLAGS)
+MSVC_CCPREFIX=
+MSVC64_CCPREFIX=
 else
 ifeq ($(SDK),)
 # Otherwise, assume the 32-bit version of VS 2008 or Win7 SDK is in the path.
@@ -69,6 +71,8 @@ MSVC64_PREFIX=LIB="$(MSVC64_LIB)" INCLUDE="$(MSVC_INCLUDE)"
 
 MSVCC = $(MSVCC_ROOT)/cl.exe $(MSVC_FLAGS)
 MSVCC64 = $(MSVCC_ROOT)/amd64/cl.exe $(MSVC_FLAGS)
+MSVC_CCPREFIX=-cc-prefix $(MSVCC_ROOT)/
+MSVC64_CCPREFIX=-cc-prefix $(MSVCC_ROOT)/amd64/
 else
 MSVCC_ROOT:=
 MSVC_PREFIX=PATH="$(SDK):$(PATH)" LIB="$(SDK_LIB);$(LIB)" INCLUDE="$(SDK_INC);$(INCLUDE)"
@@ -76,6 +80,8 @@ MSVC64_PREFIX=PATH="$(SDK64):$(PATH)" LIB="$(SDK64_LIB);$(LIB)" INCLUDE="$(SDK64
 
 MSVCC = cl.exe $(MSVC_FLAGS)
 MSVCC64 = cl.exe $(MSVC_FLAGS)
+MSVC_CCPREFIX=
+MSVC64_CCPREFIX=
 endif
 endif
 
@@ -147,47 +153,26 @@ version.res: version.rc
 version_res.o: version.rc
 	$(TOOLPREF)windres version.rc version_res.o
 
-flexdll_msvc.obj: flexdll.h flexdll.c
-	$(MSVC_PREFIX) $(MSVCC) /DMSVC -c /Fo"flexdll_msvc.obj" flexdll.c
+flexdll_initer_msvc.obj flexdll_msvc.obj: flexdll.h flexdll.c flexdll_initer.c flexlink.exe
+	$(MSVC_PREFIX) ./flexlink -v -install -o . -chain msvc $(MSVC_CCPREFIX)
 
-flexdll_msvc64.obj: flexdll.h flexdll.c
-	$(MSVC64_PREFIX) $(MSVCC64) /DMSVC /DMSVC64 -c /Fo"flexdll_msvc64.obj" flexdll.c
+flexdll_initer_msvc64.obj flexdll_msvc64.obj: flexdll.h flexdll.c flexdll_initer.c flexlink.exe
+	$(MSVC64_PREFIX) ./flexlink -v -install -o . -chain msvc64 $(MSVC64_CCPREFIX)
 
-flexdll_cygwin.o: flexdll.h flexdll.c
-	$(CYGCC) -c -DCYGWIN -o flexdll_cygwin.o flexdll.c
+flexdll_initer_cygwin.o flexdll_cygwin.o: flexdll.h flexdll.c flexdll_initer.c flexlink.exe
+	./flexlink -v -install -o . -chain cygwin
 
-flexdll_cygwin64.o: flexdll.h flexdll.c
-	$(CYG64CC) -c -DCYGWIN -o flexdll_cygwin64.o flexdll.c
+flexdll_initer_cygwin64.o flexdll_cygwin64.o: flexdll.h flexdll.c flexdll_initer.c flexlink.exe
+	./flexlink -v -install -o . -chain cygwin64
 
-flexdll_mingw.o: flexdll.h flexdll.c
-	$(MINCC) -c -DMINGW -o flexdll_mingw.o flexdll.c
+flexdll_initer_mingw.o flexdll_mingw.o: flexdll.h flexdll.c flexdll_initer.c flexlink.exe
+	./flexlink -v -install -o . -chain mingw
 
-flexdll_gnat.o: flexdll.h flexdll.c
-	gcc -c -o flexdll_gnat.o flexdll.c
+flexdll_initer_mingw64.o flexdll_mingw64.o: flexdll.h flexdll.c flexdll_initer.c flexlink.exe
+	./flexlink -v -install -o . -chain mingw64
 
-flexdll_mingw64.o: flexdll.h flexdll.c
-	$(MIN64CC) -c -DMINGW -o flexdll_mingw64.o flexdll.c
-
-flexdll_initer_msvc.obj: flexdll_initer.c
-	$(MSVC_PREFIX) $(MSVCC) -c /Fo"flexdll_initer_msvc.obj" flexdll_initer.c
-
-flexdll_initer_msvc64.obj: flexdll_initer.c
-	$(MSVC64_PREFIX) $(MSVCC64) -c /Fo"flexdll_initer_msvc64.obj" flexdll_initer.c
-
-flexdll_initer_cygwin.o: flexdll_initer.c
-	$(CYGCC) -c -o flexdll_initer_cygwin.o flexdll_initer.c
-
-flexdll_initer_cygwin64.o: flexdll_initer.c
-	$(CYG64CC) -c -o flexdll_initer_cygwin64.o flexdll_initer.c
-
-flexdll_initer_mingw.o: flexdll_initer.c
-	$(MINCC) -c -o flexdll_initer_mingw.o flexdll_initer.c
-
-flexdll_initer_gnat.o: flexdll_initer.c
-	gcc -c -o flexdll_initer_gnat.o flexdll_initer.c
-
-flexdll_initer_mingw64.o: flexdll_initer.c
-	$(MIN64CC) -c -o flexdll_initer_mingw64.o flexdll_initer.c
+flexdll_initer_gnat.o flexdll_gnat.o: flexdll.h flexdll.c flexdll_initer.c flexlink.exe
+	./flexlink -v -install -o . -chain gnat
 
 
 demo_msvc: flexlink.exe flexdll_msvc.obj flexdll_initer_msvc.obj

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -13,6 +13,7 @@ let underscore = ref true
 
 let machine : [ `x86 | `x64 ] ref = ref `x86
 
+let runtime_objects_dir = ref ""
 let cc_prefix = ref ""
 let noexport = ref false
 let custom_crt = ref false
@@ -216,6 +217,9 @@ let specs = [
 
   "-cc-prefix", Arg.Set_string cc_prefix,
   "<file> Add an explicit directory or a prefix in front of the C compiler (cl / gcc) and other tools";
+
+  "-runtime-objects", Arg.Set_string runtime_objects_dir,
+  "<dir> Specify in which directory the flexdll runtime objects are found";
 
   "--", Arg.Rest (fun s -> extra_args := s :: !extra_args),
   " Following arguments are passed verbatim to the linker";

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -13,6 +13,7 @@ let underscore = ref true
 
 let machine : [ `x86 | `x64 ] ref = ref `x86
 
+let cc_prefix = ref ""
 let noexport = ref false
 let custom_crt = ref false
 let reexport_from_implibs = ref true
@@ -212,6 +213,9 @@ let specs = [
 
   "-install", Arg.Unit (fun () -> mode := `INSTALL),
   " Compile runtime support file for the selected toolchain";
+
+  "-cc-prefix", Arg.Set_string cc_prefix,
+  "<file> Add an explicit directory or a prefix in front of the C compiler (cl / gcc) and other tools";
 
   "--", Arg.Rest (fun s -> extra_args := s :: !extra_args),
   " Following arguments are passed verbatim to the linker";

--- a/cmdline.ml
+++ b/cmdline.ml
@@ -36,7 +36,7 @@ let exts = ref []
 let output_file = ref ""
 let exe_mode : [`DLL | `EXE | `MAINDLL] ref = ref `DLL
 let extra_args = ref []
-let mode : [`NORMAL | `DUMP | `PATCH] ref = ref `NORMAL
+let mode : [`NORMAL | `DUMP | `PATCH | `INSTALL] ref = ref `NORMAL
 let defexports = ref []
 let noentry = ref false
 let use_cygpath = ref true
@@ -209,6 +209,9 @@ let specs = [
 
   "-U", Arg.String (fun _ -> ()),
   "<symbol> (Ignored)";
+
+  "-install", Arg.Unit (fun () -> mode := `INSTALL),
+  " Compile runtime support file for the selected toolchain";
 
   "--", Arg.Rest (fun s -> extra_args := s :: !extra_args),
   " Following arguments are passed verbatim to the linker";

--- a/reloc.ml
+++ b/reloc.ml
@@ -33,6 +33,10 @@ let flexdir =
   with Not_found ->
     Filename.dirname Sys.executable_name
 
+let runtime_objects_dir =
+  if !runtime_objects_dir = "" then flexdir
+  else !runtime_objects_dir
+
 let ext_obj () =
   if !toolchain = `MSVC || !toolchain = `MSVC64 then ".obj" else ".o"
 
@@ -1375,7 +1379,7 @@ let dump fn =
 let all_files () =
   let files = List.rev (List.map compile_if_needed !files) in
   let f obj =
-    let fn = Filename.concat flexdir obj in
+    let fn = Filename.concat runtime_objects_dir obj in
     (* Allow the obj files to be stored in a different location *)
     if file_exists fn <> None then
       fn


### PR DESCRIPTION
As discussed with @dra27, the idea is to let flexlink creates its own object files (flexdll_{initer_,}CHAIN.{obj,o}`).  The following options are added to flexink:

  - `-install` : ask flexlink to compile the two objects files for the selected `-chain` and put them in the directory specified by `-o`.

 - `-cc-prefix <PREFIX>`: a string to be prepended to all tools of the selected toolchain; this can be used for gcc (mingw/cygwin) to specify an actual prefix such as `i686-w64-mingw32-` (defaults are used for those toolchains) and for cl (msvc) to specify an explicit directory (typically to select the 64-bit cl.exe even though it is not currently in the path).  This option is used in the build system itself, but it should not be required by external users; they are likely to set up the path to find the correct cl.exe.

 - `-runtime-objects <DIR>`: specify the directory where runtime objects should be looked up.

@dra27 : please comment!