### PR TITLE
Allow linking C++

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Next version
 - GPR#49: Adding support for 64bit GNAT compiler (Johannes Kanig)
 - GPR#64: Fix problem with setting page permission during relocation (report
   by Dmitry Bely)
+- GPR#48: Enable linking of C++ object files for mingw ports (David Allsopp)
 
 Version 0.37
 - Bug fix: the IMAGE_SCN_LNK_NRELOC_OVFL section flag was not propertly reset when

--- a/reloc.ml
+++ b/reloc.ml
@@ -662,7 +662,10 @@ let build_dll link_exe output_file files exts extra_args =
   let loaded_filenames : (string,unit) Hashtbl.t = Hashtbl.create 16 in
   let read_file fn =
     if Lib.is_dll fn then `Lib ([], dll_exports fn)
-    else Lib.read fn
+    else begin
+      if !verbose >= 2 then Printf.printf "** open: %s\n" fn;
+      Lib.read fn
+    end
   in
   let files = List.map (fun fn -> fn, read_file fn) files in
 

--- a/reloc.ml
+++ b/reloc.ml
@@ -1247,7 +1247,7 @@ let setup_toolchain () =
       List.iter (Printf.printf "  %s\n%!") lib_search_dirs;
     end;
     default_libs :=
-      ["-lmingw32"; "-lgcc"; "-lmoldname"; "-lmingwex"; "-lmsvcrt";
+      ["-lmingw32"; "-lgcc"; "-lgcc_eh"; "-lmoldname"; "-lmingwex"; "-lmsvcrt";
        "-luser32"; "-lkernel32"; "-ladvapi32"; "-lshell32" ];
     if !exe_mode = `EXE then default_libs := "crt2.o" :: !default_libs
     else default_libs := "dllcrt2.o" :: !default_libs

--- a/reloc.ml
+++ b/reloc.ml
@@ -634,6 +634,9 @@ let needed imported defined unalias obj =
     | Some s when not (StrSet.mem name defined) ->
         imported := StrSet.add s !imported;
         if StrSet.mem s defined then s else name
+    | None when not (StrSet.mem name defined) && StrSet.mem ("__imp_" ^ name) defined ->
+        imported := StrSet.add ("__imp_" ^ name) !imported;
+        "__imp_" ^ name
     | _ -> name
   in
   List.fold_left


### PR DESCRIPTION
At least for mingw64! These two changes together have allowed me to link applications using the ocaml-mccs C++ stubs.

I'm reasonably confident that the change to add `-lgcc_eh` is correct (because we already add `-lgcc`). I'm not so totally confident about the change in `Reloc.needed`, although I am confident that this only changes the behaviour for symbols which previously would have caused linker errors.