### PR TITLE
Fix HEADER_DIR for OCaml trunk (4.08 and up)

### DIFF
--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -49,7 +49,7 @@ cd ocaml
 
 MAKEOCAML=make
 CONFIG_DIR=config
-HEADER_DIR=byterun/caml
+HEADER_DIR=runtime/caml
 
 case $OCAMLBRANCH in
     4.03|4.04)
@@ -59,6 +59,8 @@ case $OCAMLBRANCH in
     4.05)
         HEADER_DIR=config
         ;;
+    4.06|4.07)
+        HEADER_DIR=byterun/caml
 esac
 
 if [ $OCAMLBRANCH = "4.03" ] ; then


### PR DESCRIPTION
Appveyor build should not fail on OCaml trunk branch anymore