### PR TITLE
Fix problem with setting page permission during relocation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ Next version
 - GPR#58: Bug fix: fix -custom-crt regression (Dmitry Bely)
 - GPR#61: Ignore x64 debug relocs (Dmitry Bely)
 - GPR#49: Adding support for 64bit GNAT compiler (Johannes Kanig)
+- GPR#64: Fix problem with setting page permission during relocation (report
+  by Dmitry Bely)
 
 Version 0.37
 - Bug fix: the IMAGE_SCN_LNK_NRELOC_OVFL section flag was not propertly reset when


### PR DESCRIPTION
Another take at #57, avoiding repeated calls to VirtualProtect on the same pages for performance reasons.

Loading the big .cmxs I mentioned in #57 now takes about 0.22s (against 0.20s before the change, and against 0.65s with the version in #57).  One could try to be even more clever and group relocation that fall in adjacent pages, but this becomes a bit more tricky.