### PR TITLE
Fix FLEXDLL_RELOCATE passing

### DIFF
--- a/flexdll.c
+++ b/flexdll.c
@@ -377,12 +377,16 @@ void *flexdll_wdlopen(const wchar_t *file, int mode) {
   error = 0;
   if (!file) return &main_unit;
 
-#ifdef CYGWIN
+  /* putenv() only modifies CRT's copy of the environment. That works for
+     one shared CRT lib, but fails when parent/child process CRTs are
+     different. Actually, GetEnvironmentVariable/SetEnvironmentVariable is
+     enough but we preserve the legacy method for backward compatibility */
   sprintf(flexdll_relocate_env,"%p",relocate);
+  SetEnvironmentVariable("FLEXDLL_RELOCATE", flexdll_relocate_env);
+#ifdef CYGWIN
   setenv("FLEXDLL_RELOCATE", flexdll_relocate_env, 1);
 #else
 #if __STDC_SECURE_LIB__ >= 200411L
-  sprintf(flexdll_relocate_env,"%p",relocate);
   _putenv_s("FLEXDLL_RELOCATE", flexdll_relocate_env);
 #else
   {

--- a/flexdll_initer.c
+++ b/flexdll_initer.c
@@ -24,8 +24,16 @@ extern int reloctbl;
 
 static int flexdll_init() {
   func *sym = 0;
-  char *s = getenv("FLEXDLL_RELOCATE");
-  if (!s) { fprintf(stderr, "Cannot find FLEXDLL_RELOCATE\n"); return FALSE; }
+  char *s, buf[256];
+  DWORD len = GetEnvironmentVariable("FLEXDLL_RELOCATE", buf, sizeof(buf));
+  if (len > 0 && len <= sizeof(buf)) {
+    s = buf;
+  }
+  else {
+    /* fallback to the legacy method */
+    s = getenv("FLEXDLL_RELOCATE");
+    if (!s) { fprintf(stderr, "Cannot find FLEXDLL_RELOCATE\n"); return FALSE; }
+  }
   sscanf(s,"%p",&sym);
   /* sym = 0 means "loaded not for execution" */
   if (!sym || sym(&reloctbl)) return TRUE;


### PR DESCRIPTION
A simple scenario to demonstrate the existing problem with getenv()/putenv() for passing the relocation table pointer:
main exe (linked with msvcrt) -> dll1 (msvcrtd) -> dll2 (msvcrt)
(arrows mean flexdll_dlopen()). This way dll1 will fail to pass the pointer to dll2.