### PR TITLE
Fix #67 - Reduce command limit to 8161

### DIFF
--- a/reloc.ml
+++ b/reloc.ml
@@ -68,7 +68,7 @@ let read_file fn =
 let get_output ?(use_bash = false) ?(accept_error=false) cmd =
   let fn = Filename.temp_file "flexdll" "" in
   let cmd' = cmd ^ " > " ^ (Filename.quote fn) in
-    if String.length cmd' < 8182 && not use_bash then
+    if String.length cmd' < 8161 && not use_bash then
       begin
         if (Sys.command cmd' <> 0) && not accept_error
         then failwith ("Cannot run " ^ cmd);

--- a/reloc.ml
+++ b/reloc.ml
@@ -64,11 +64,16 @@ let read_file fn =
   close_in ic;
   List.rev !r
 
+(* This is the longest command which can be passed to [Sys.command] *)
+let max_command_length =
+  let processor = try Sys.getenv "COMSPEC" with Not_found -> "cmd.exe" in
+  (* The 4 is from the " /c " *)
+  8191 - String.length processor - 4
 
 let get_output ?(use_bash = false) ?(accept_error=false) cmd =
   let fn = Filename.temp_file "flexdll" "" in
   let cmd' = cmd ^ " > " ^ (Filename.quote fn) in
-    if String.length cmd' < 8161 && not use_bash then
+    if String.length cmd' < max_command_length && not use_bash then
       begin
         if (Sys.command cmd' <> 0) && not accept_error
         then failwith ("Cannot run " ^ cmd);

--- a/reloc.ml
+++ b/reloc.ml
@@ -206,7 +206,7 @@ let run_command cmdline cmd =
   (* note: for Cygwin, using bash allow to follow symlinks to find
      gcc... *)
   if !toolchain = `CYGWIN || !toolchain = `CYGWIN64 ||
-     String.length cmd_quiet >= 8192
+     String.length cmd_quiet >= max_command_length
   then begin
     (* Dump the command in a text file and apply bash to it. *)
     let (fn, oc) = open_temp_file "longcmd" "" in


### PR DESCRIPTION
This fixes #67 - on `esy`, we were hitting a case where we were supplied a command with a length of _8178_ - this would give us a 'Command line too long error'.

It's a bit strange, because the officially documented limit for the command line length is _8191_. 

However, I tested this with a quick sample program (attached: __[test.c.txt](https://github.com/alainfrisch/flexdll/files/2385155/test.c.txt)__)

The results were surprising - I was getting the exception at _8161_ characters long:
```
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
Iteration 8160 - return code: 0
The command line is too long.
Iteration 8161 - return code: 1
```

I considered that it might be a difference using the mingw toolchain vs a native compiler, but even compiling with the VS `cl` compiler, I hit the same limit.

Lowering this limit to `8161` allows for `esy` to build successfully on Windows.
