### PR TITLE
make it that -custom-crt does not prevent linking with libcmt.lib

### DIFF
--- a/reloc.ml
+++ b/reloc.ml
@@ -1002,7 +1002,7 @@ let build_dll link_exe output_file files exts extra_args =
         let c = open_out implib in output_string c "x"; close_out c;
         let _impexp = add_temp (Filename.chop_suffix implib ".lib" ^ ".exp") in
         let extra_args =
-          if !custom_crt then "/nodefaultlib:LIBCMT /nodefaultlib:MSVCRT " ^ extra_args
+          if !custom_crt then "/nodefaultlib:MSVCRT " ^ extra_args
           else "msvcrt.lib " ^ extra_args
         in
 


### PR DESCRIPTION
*c.f.* #51

This does removes the addition of the `/nodefaultlib:LIBCMT` in the command line when using the `-custom-crt` option.
With this, we can successfully link an OCaml program with LIBCMT by invoking ocamlopt with `-ccopt -custom-crt -cclib libcmt.lib` (with a suitably compiled runtime library).

fixes issue #51