### PR TITLE
Added compatibility layer for newer ocaml.

### DIFF
--- a/Compat407.ml
+++ b/Compat407.ml
@@ -1,0 +1,9 @@
+(************************************************************************)
+(*   FlexDLL                                                            *)
+(*   Alain Frisch                                                       *)
+(*                                                                      *)
+(*   Copyright 2007 Institut National de Recherche en Informatique et   *)
+(*   en Automatique.                                                    *)
+(************************************************************************)
+
+module Stdlib = Pervasives

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ COMPILER-$(OCAML_VERSION):
 
 test_ver = $(shell if [ $(OCAML_VERSION) -lt $(1) ] ; then echo lt ; fi)
 
-Compat.ml: COMPILER-$(OCAML_VERSION) $(if $(call test_ver,4020),Compat402.ml) $(if $(call test_ver,4030),Compat403.ml) $(if $(call test_ver,4050),Compat405.ml) $(if $(call test_ver,4060),Compat406.ml)
+Compat.ml: COMPILER-$(OCAML_VERSION) $(if $(call test_ver,4020),Compat402.ml) $(if $(call test_ver,4030),Compat403.ml) $(if $(call test_ver,4050),Compat405.ml) $(if $(call test_ver,4060),Compat406.ml) $(if $(call test_ver,4070),Compat407.ml)
 	cat $^ > $@
 
 flexlink.exe: $(OBJS) $(RES)

--- a/reloc.ml
+++ b/reloc.ml
@@ -498,7 +498,7 @@ let add_export_table obj exports symname =
   let strings = Buffer.create 1024 in
   let strsym = Symbol.intern sect 0l in
   obj.symbols <- strsym :: (Symbol.export symname sect 0l) :: obj.symbols;
-  let exports = List.sort Pervasives.compare exports in
+  let exports = List.sort Stdlib.compare exports in
   (* The runtime library assumes that names are sorted! *)
   int_to_buf data (List.length exports);
   List.iter


### PR DESCRIPTION
Pervasives is deprecated since ocaml 4.08 and should be replaced
by Stdlib. 