### PR TITLE
Spring cleaning

### DIFF
--- a/coff.ml
+++ b/coff.ml
@@ -344,7 +344,7 @@ module Symbol = struct
     }
 
   let is_extern = function
-    |  { storage = 2; section = `Num 0; value = 0l } -> true
+    | { storage = 2; section = `Num 0; value = 0l } -> true
     | _ -> false
 
   let is_export = function
@@ -481,7 +481,7 @@ end
 module Section = struct
   let create name flags = {
     sec_pos = (-1); sec_name = name; data = `String (Bytes.of_string ""); relocs = [];
-    vaddress = 0l; vsize = 0l;  sec_opts = flags;
+    vaddress = 0l; vsize = 0l; sec_opts = flags;
   }
 
   let nreloc_ovfl = 0x01000000l
@@ -869,7 +869,7 @@ module Lib = struct
       let buf = read ic (pos_in ic) 60 in
       let base = pos_in ic in
       let size = int_of_string (strz (Bytes.sub buf 48 10) 0 ' ') in
-      let name = strz (Bytes.sub buf 0 16) 0 ' '  in
+      let name = strz (Bytes.sub buf 0 16) 0 ' ' in
       begin match name with
         | "/" | "" -> ()
         | "//" -> strtbl := read ic (pos_in ic) size

--- a/coff.ml
+++ b/coff.ml
@@ -296,8 +296,7 @@ let rec dump ic pos len w =
     | '\032'..'\127' as c -> print_char c
     | _ -> print_char '.'
   done;
-  Printf.printf "\n";
-  flush stdout;
+  Printf.printf "\n%!";
   dump ic (pos + l) (len - l) w
 
 module Symbol = struct
@@ -736,7 +735,7 @@ module Coff = struct
                 s.auxs <- Bytes.make (Bytes.length auxs) '\000'
             | _ ->
                 Symbol.dump s;
-                Printf.printf "aux=%S\n" (Bytes.to_string s.auxs);
+                Printf.printf "aux=%S\n%!" (Bytes.to_string s.auxs);
                 assert false);
          (match s.section with
             | `Num i when i > 0 && i <= Array.length sections ->
@@ -773,7 +772,7 @@ module Coff = struct
     Printf.printf "opts:    0x%x\n" x.opts;
     List.iter Symbol.dump x.symbols;
     List.iter Section.dump x.sections;
-    ()
+    flush stdout
 
   let put oc x =
     emit_int16 oc x.machine;

--- a/reloc.ml
+++ b/reloc.ml
@@ -406,7 +406,7 @@ let add_reloc_table obj obj_name p =
                 k rel.symbol.sym_name obj_name
             in
             failwith msg
-(*            Printf.eprintf "%s\n" msg;
+(*            Printf.eprintf "%s\n%!" msg;
             0x0001 *)
       in
       int_to_buf data kind;
@@ -612,7 +612,7 @@ let patch_output filename =
       in
       begin try Stacksize.set_stack_reserve filename x
       with exn ->
-        Printf.eprintf "Cannot set stack reserve: %s"
+        Printf.eprintf "Cannot set stack reserve: %s\n%!"
           (Printexc.to_string exn)
       end
   | None -> ()
@@ -824,7 +824,7 @@ let build_dll link_exe output_file files exts extra_args =
 
   let add_reloc name obj imps =
     if !show_imports && not (StrSet.is_empty imps) then (
-      Printf.printf "** Imported symbols for %s:\n" name;
+      Printf.printf "** Imported symbols for %s:\n%!" name;
       StrSet.iter print_endline imps
     );
     let sym = add_reloc_table obj name (fun s -> StrSet.mem s.sym_name imps) in
@@ -896,7 +896,7 @@ let build_dll link_exe output_file files exts extra_args =
           (* the linker will find this object in this library *)
       else begin
         if !explain then
-          Printf.printf "Library object %s(%s) needs to be rewritten\n"
+          Printf.printf "Library object %s(%s) needs to be rewritten\n%!"
             libname objname;
         Hashtbl.add redirect libname
           (close_obj (Printf.sprintf "%s(%s)" libname objname) imps obj)
@@ -909,6 +909,7 @@ let build_dll link_exe output_file files exts extra_args =
     StrSet.iter print_endline !exported;
     Printf.printf "** Symbols from import libs:\n";
     StrSet.iter print_endline !imported_from_implib;
+    flush stdout
   );
 
   if !reexport_from_implibs then
@@ -919,7 +920,7 @@ let build_dll link_exe output_file files exts extra_args =
 
   if not (StrSet.is_empty !imported) then begin
 (*
-    Printf.printf "** __imp symbols:\n";
+    Printf.printf "** __imp symbols:\n%!";
     StrSet.iter print_endline !imported;
 *)
     add_import_table obj (StrSet.elements !imported);
@@ -1225,7 +1226,8 @@ let setup_toolchain () =
     search_path := !dirs @ lib_search_dirs;
     if !verbose >= 1 then begin
       print_endline "lib search dirs:";
-      List.iter (Printf.printf "  %s\n%!") lib_search_dirs;
+      List.iter (Printf.printf "  %s\n") lib_search_dirs;
+      flush stdout
     end;
     default_libs :=
       ["-lmingw32"; "-lgcc"; "-lmoldname"; "-lmingwex"; "-lmsvcrt";
@@ -1346,7 +1348,8 @@ let dump fn =
         objs;
       List.iter
         (fun (s,i) -> Printf.printf "** import: %s (%i)\n" s i)
-        imports
+        imports;
+      flush stdout
   | `Obj o ->
       Coff.dump o
 
@@ -1403,7 +1406,8 @@ let main () =
     if !use_default_libs then begin
       Printf.printf "** Default libraries:\n";
       List.iter print_endline !default_libs;
-    end
+    end;
+    flush stdout
    );
   let files = all_files () in
   match !mode with

--- a/reloc.ml
+++ b/reloc.ml
@@ -312,7 +312,7 @@ let int_to_buf b i =
 let exportable s =
   match !machine with
   | `x86 ->
-      s <> "" && (s.[0] = '_'  || s.[0] = '?')
+      s <> "" && (s.[0] = '_' || s.[0] = '?')
   | `x64 ->
       if String.length s > 2 && s.[0] = '?' && s.[1] = '?' then false
       else true
@@ -393,7 +393,7 @@ let add_reloc_table obj obj_name p =
                           0x0b (* IMAGE_REL_{I386|AMD64}_SECREL*) ) ->
             0x0100 (* debug relocs: ignore *)
 
-        | _, k  ->
+        | _, k ->
             let msg =
               Printf.sprintf "Unsupported relocation kind %04x for %s in %s"
                 k rel.symbol.sym_name obj_name
@@ -456,7 +456,7 @@ let add_reloc_table obj obj_name p =
       Reloc.abs !machine sect (Int32.of_int (Buffer.length data)) secsym;
       int_to_buf data (Int32.to_int min);
       Reloc.abs !machine sect (Int32.of_int (Buffer.length data)) secsym;
-      int_to_buf data (Int32.to_int  max);
+      int_to_buf data (Int32.to_int max);
       int_to_buf data 0;
     )
     !nonwr;
@@ -502,7 +502,7 @@ let add_export_table obj exports symname =
   (* The runtime library assumes that names are sorted! *)
   int_to_buf data (List.length exports);
   List.iter
-    (fun s  ->
+    (fun s ->
        let sym = Symbol.extern s in
        obj.symbols <- sym :: obj.symbols;
        Reloc.abs !machine sect (Int32.of_int (Buffer.length data)) sym;
@@ -527,7 +527,7 @@ let add_master_reloc_table obj names symname =
   let data = Buffer.create 1024 in
   obj.symbols <- (Symbol.export symname sect 0l) :: obj.symbols;
   List.iter
-    (fun s  ->
+    (fun s ->
        let sym = Symbol.extern s in
        obj.symbols <- sym :: obj.symbols;
        Reloc.abs !machine sect (Int32.of_int (Buffer.length data)) sym;
@@ -799,7 +799,7 @@ let build_dll link_exe output_file files exts extra_args =
 
   (* Second step: transitive closure, starting from given objects *)
 
-  let libobjects  = Hashtbl.create 16 in
+  let libobjects = Hashtbl.create 16 in
   let reloctbls = ref [] in
   let exported = ref StrSet.empty in
 
@@ -1217,7 +1217,7 @@ let setup_toolchain () =
       |> remove_duplicate_paths
     in
     search_path := !dirs @ lib_search_dirs;
-    if !verbose >= 1  then begin
+    if !verbose >= 1 then begin
       print_endline "lib search dirs:";
       List.iter (Printf.printf "  %s\n%!") lib_search_dirs;
     end;
@@ -1359,8 +1359,8 @@ let all_files () =
   | `CYGWIN -> "cygwin.o"
   | `CYGWIN64 -> "cygwin64.o"
   | `MINGW64 -> "mingw64.o"
-  | `GNAT     -> "gnat.o"
-  | `GNAT64     -> "gnat64.o"
+  | `GNAT -> "gnat.o"
+  | `GNAT64 -> "gnat64.o"
   | `MINGW | `LIGHTLD -> "mingw.o" in
   if !exe_mode <> `DLL then
     if !add_flexdll_obj then f ("flexdll_" ^ tc) :: files


### PR DESCRIPTION
Spring is here, even if most of us are locked down! Nothing profound here, but I got tired of adding `if !verbose >= 1 then Printf.printf` when poking around, so finally added a debug function. I was also debugging something where I was suspicious that stderr from a command might be coming out of order from unflushed stdout messages from flexlink - it turned out they weren't, but I've added explicit `flush` or `%!` where appropriate to all messages in `Reloc`