### PR TITLE
Restore building on very old OCamls

### DIFF
--- a/Compat401.ml
+++ b/Compat401.ml
@@ -6,15 +6,5 @@
 (*   en Automatique.                                                    *)
 (************************************************************************)
 
-(* Back-port required functionality from Bytes in 4.02.0 *)
-type bytes = string
-module Bytes = struct
-  include String
-
-  let blit_string = blit
-  let sub_string = sub
-  let of_string x = x
-  let to_string x = x
-  let cat = (^)
-end
-let output_bytes = output_string
+(* Introduced in 4.01.0 *)
+let ( |> ) x f = f x

--- a/Compat402.ml
+++ b/Compat402.ml
@@ -19,11 +19,5 @@ module Bytes = struct
 end
 let output_bytes = output_string
 
-module Buffer = struct
-  include Buffer
-
-  let to_bytes = contents
-end
-
 (* Introduced in 4.01.0 *)
 let ( |> ) x f = f x

--- a/Compat406.ml
+++ b/Compat406.ml
@@ -9,6 +9,9 @@
 module Buffer = struct
   include Buffer
 
+  (* Strictly speaking this should be in Compat402.ml *)
+  let to_bytes = contents
+
   (* Taken from 4.06.0 *)
   let add_utf_16le_uchar b u = match Uchar.to_int u with
   | u when u < 0 -> assert false

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,15 @@ COMPILER-$(OCAML_VERSION):
 
 test_ver = $(shell if [ $(OCAML_VERSION) -lt $(1) ] ; then echo lt ; fi)
 
-Compat.ml: COMPILER-$(OCAML_VERSION) $(if $(call test_ver,4020),Compat402.ml) $(if $(call test_ver,4030),Compat403.ml) $(if $(call test_ver,4050),Compat405.ml) $(if $(call test_ver,4060),Compat406.ml) $(if $(call test_ver,4070),Compat407.ml)
+# This list must be in order
+COMPAT_MODULES := $(if $(call test_ver,4010),Compat401) \
+                  $(if $(call test_ver,4020),Compat402) \
+                  $(if $(call test_ver,4030),Compat403) \
+                  $(if $(call test_ver,4050),Compat405) \
+                  $(if $(call test_ver,4060),Compat406) \
+                  $(if $(call test_ver,4070),Compat407)
+
+Compat.ml: COMPILER-$(OCAML_VERSION) $(addsuffix .ml, $(COMPAT_MODULES))
 	cat $^ > $@
 
 flexlink.exe: $(OBJS) $(RES)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,11 @@ environment:
     - OCAMLBRANCH: 4.05
     - OCAMLBRANCH: 4.06
     - OCAMLBRANCH: 4.07
+    - OCAMLBRANCH: 4.08
+    - OCAMLBRANCH: 4.09
+    - OCAMLBRANCH: 4.10
+      SKIP_OCAML_TEST: no
+    - OCAMLBRANCH: 4.11
       SKIP_OCAML_TEST: no
     - OCAMLBRANCH: trunk
       SKIP_OCAML_TEST: no

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,12 @@ environment:
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
     CYG_CACHE: C:/cygwin/var/cache/setup
   matrix:
+    - OCAMLBRANCH: 3.11
+    - OCAMLBRANCH: 3.12
+      OCAMLREV: 1
+    - OCAMLBRANCH: 4.00
+    - OCAMLBRANCH: 4.01
+    - OCAMLBRANCH: 4.02
     - OCAMLBRANCH: 4.03
       SKIP_OCAML_TEST: no
     - OCAMLBRANCH: 4.04
@@ -28,10 +34,12 @@ install:
   # cygpath behaves crazily), but after the MSVC one.
   - set Path=C:\cygwin\bin;%OCAMLROOT%\bin;C:\flexdll;%Path%
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
-  - '"%CYG_ROOT%\setup-x86.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages cygwin64-gcc-core > nul'
+  - '"%CYG_ROOT%\setup-x86.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages cygwin64-gcc-core,unzip > nul'
   - '%CYG_ROOT%\bin\bash -lc "x86_64-pc-cygwin-gcc --version" > nul || "%CYG_ROOT%\setup-x86.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --upgrade-also > nul'
   - '%CYG_ROOT%\bin\bash -lc "cygcheck -dc cygwin"'
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\amd64\vcvars64.bat"
+  - appveyor DownloadFile "https://github.com/alainfrisch/flexdll/archive/0.37.tar.gz" -FileName "flexdll.tar.gz"
+  - appveyor DownloadFile "https://github.com/alainfrisch/flexdll/releases/download/0.37/flexdll-bin-0.37.zip" -FileName "flexdll.zip"
   - appveyor DownloadFile "https://raw.githubusercontent.com/ocaml/ocaml/trunk/tools/msvs-promote-path" -FileName "msvs-promote-path"
 
 build_script:

--- a/reloc.ml
+++ b/reloc.ml
@@ -180,11 +180,8 @@ let build_diversion lst =
       ) (List.filter (fun f -> f <> "") lst)
   in
   let utf16, lst =
-    match List.map toutf16 lst with
-    | lst ->
-        true, lst
-    | exception Not_utf8 ->
-        false, lst
+    try true, List.map toutf16 lst
+    with Not_utf8 -> false, lst
   in
   if utf16 then output_string oc "\xFF\xFE"; (* LE BOM *)
   List.iter (fun s -> output_string oc s) lst;


### PR DESCRIPTION
I intend to overhaul this to switch to GitHub Actions, as we'll get much better parallelism, but in the meantime.

I do not propose that we actively support building `flexlink` on OCaml 3.11, but it is quite useful that it basically still does (especially when opam finally allows installing the old Windows compilers in switches). I propose that dropping support for building flexlink with very old OCamls should be done consciously as part of a larger - long overdue - overhaul of the code, not just because of little patches.

With that in mind:
- restoring 4.02 support involves a slight hack to the Compat system. As part of #85, I will switch this to be rather better pre-processed, but for now it just involves moving `Buffer.to_bytes` into the Compat406 and not caring that it gets redefined for OCaml 4.03-4.05 when it doesn't need to be
- Restoring 3.11-4.01 support involves converting a single match on an `exception` back to `try`

The AppVeyor matrix is then expanded - I debated getting it to skip most versions for PRs, but I propose just putting this in as-is for now, given that the traffic on this repo I so low...