### PR TITLE
Stop passing --image-base on Cygwin64

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 Next version
+- GPR#89: Stop passing --image-base on Cygwin64 - Cygwin64 DLLs should load at
+  0x4:00000000-0x6:00000000 if not rebased or 0x2:00000000-0x4:00000000 if rebased. (David Allsopp)
 - GPR#90: Fix passing NULL to flexdll_dlopen on non-Cygwin builds (David Allsopp)
 
 Version 0.38

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -164,6 +164,8 @@ for CHAIN in $CHAINS; do
 done
 
 for CHAIN in $CHAINS; do
+    # Decision on operation of Cygwin64 not yet taken
+    if [ "$CHAIN" = "cygwin64" ] ; then continue; fi
     run "make demo_$CHAIN" make demo_$CHAIN
 done
 

--- a/flexdll.c
+++ b/flexdll.c
@@ -224,7 +224,7 @@ static void relocate(resolver f, void *data, reloctbl *tbl) {
       s -= (INT_PTR)(ptr -> addr) + 4;
       s += *((INT32*) ptr -> addr);
       if (s != (INT32) s) {
-        sprintf(error_buffer, "flexdll error: cannot relocate RELOC_REL32, target is too far: %p  %p", (void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
+        sprintf(error_buffer, "flexdll error: cannot relocate %s RELOC_REL32, target is too far: %p  %p", ptr->name, (void *)((UINT_PTR) s), (void *) ((UINT_PTR)(INT32) s));
         error = 3;
         goto restore;
       }

--- a/reloc.ml
+++ b/reloc.ml
@@ -1075,9 +1075,6 @@ let build_dll link_exe output_file files exts extra_args =
             close_out oc;
             Filename.quote def_file
         in
-        let extra_args =
-          if !machine = `x64 then "-Xlinker --image-base -Xlinker 0x10000 " ^ extra_args else extra_args
-        in
         Printf.sprintf
           "%s %s%s -L. %s %s -o %s %s %s %s %s"
           !gcc


### PR DESCRIPTION
On Cygwin64, `--image-base 0x10000` is always passed to the linker. This generates invalid DLLs for Cygwin64. This has never worked reliably, as DLLs need unique base addresses on Cygwin to survive fork. However, since version 4.4.4 Cygwin's rebase forces DLLs to the correct base address in 0x2:00000000-0x4:00000000. Since Cygwin64 executables load in 0x1:00000000-0x1:80000000, DLLs are always too far RELOC_REL32.

Rather than dynamically generating branch islands, the new approach on the OCaml-side is to return to using `__declspec(dllimport)` only, which will cause the linker to do that work for us, as it should.

Regardless of the solution, `--image-base` should cease being passed to the linker on Cygwin64.