### PR TITLE
Fix flexdll_dlopen when passed NULL file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+Next version
+- GPR#90: Fix passing NULL to flexdll_dlopen on non-Cygwin builds (David Allsopp)
+
 Version 0.38
 - GPR#58: Bug fix: fix -custom-crt regression (Dmitry Bely)
 - GPR#61: Ignore x64 debug relocs (Dmitry Bely)

--- a/flexdll.c
+++ b/flexdll.c
@@ -425,16 +425,20 @@ void *flexdll_wdlopen(const wchar_t *file, int mode) {
 
 void *flexdll_dlopen(const char *file, int mode)
 {
-  wchar_t * p;
+  wchar_t * p = NULL;
   int nbr;
   void * handle;
 
-  nbr = MultiByteToWideChar(CP_THREAD_ACP, 0, file, -1, NULL, 0);
-  if (nbr == 0) { if (!error) error = 1; return NULL; }
-  p = malloc(nbr*sizeof(*p));
-  MultiByteToWideChar(CP_THREAD_ACP, 0, file, -1, p, nbr);
+  if (file) {
+    nbr = MultiByteToWideChar(CP_THREAD_ACP, 0, file, -1, NULL, 0);
+    if (nbr == 0) { if (!error) error = 1; return NULL; }
+    p = malloc(nbr*sizeof(*p));
+    MultiByteToWideChar(CP_THREAD_ACP, 0, file, -1, p, nbr);
+  }
+
   handle = flexdll_wdlopen(p, mode);
-  free(p);
+
+  if (p) free(p);
 
   return handle;
 }


### PR DESCRIPTION
On native Windows (i.e. not Cygwin), flexdll_dlopen is a stub function for converting an ANSI filename to Unicode and then calling
flexdll_wdlopen. However, it's permitted to pass NULL in order to get a handle to the running process, but this isn't implemented in the stub, which fails.

As far as I can tell, this means ocamlnat has been broken since OCaml 4.06!