### PR TITLE
Correct the parsing of /n COFF lib headers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+Next version
+- GPR#94: Fix parsing of COFF archives to ignore <XFGHASH> headers, allowing the Windows 11 SDK to be used. (David Allsopp)
+
 Version 0.39
 - GPR#89: Stop passing --image-base on Cygwin64 - Cygwin64 DLLs should load at
   0x4:00000000-0x6:00000000 if not rebased or 0x2:00000000-0x4:00000000 if rebased. (David Allsopp)

--- a/coff.ml
+++ b/coff.ml
@@ -873,8 +873,15 @@ module Lib = struct
         | "/" | "" -> ()
         | "//" -> strtbl := read ic (pos_in ic) size
         | s when s.[0] = '/' ->
-            let ofs = int_of_string (String.sub s 1 (String.length s - 1)) in
-            obj size (strz !strtbl ofs '\000')
+            let ofs =
+              try Scanf.sscanf s "/%u%!" (fun x -> x)
+              with Scanf.Scan_failure _
+                 | Failure _
+                 | End_of_file -> -1
+            in
+              (* Ignore special sections which we don't know about *)
+              if ofs >= 0 then
+                obj size (strz !strtbl ofs '\000')
         | s when s.[String.length s - 1] = '/' ->
             let s = String.sub s 0 (String.length s - 1) in
             obj size s


### PR DESCRIPTION
COFF defines any archive header beginning with `/` as special. Before, we assumed that if the header was neither `/` nor `//` then it must be `/n` and parsed accordingly. That breaks with the new `/<XFGHASH>/` header in the Windows 11 SDK.

The fact the new header begins with `/` means it should not just be interpreted as an object - the solution I've gone with here is to harden the parsing of `/n` to ignore headers where _`n`_ is not a positive decimal integer.