### PR TITLE
AppVeyor updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,11 +27,12 @@ environment:
     - OCAMLBRANCH: 4.09
     - OCAMLBRANCH: 4.10
     - OCAMLBRANCH: 4.11
-      SKIP_OCAML_TEST: no
       OCAML_PORT: mingw
       ARTEFACTS: yes
       MSVS_PREFERENCE: SDK7.0
     - OCAMLBRANCH: 4.12
+      SKIP_OCAML_TEST: no
+    - OCAMLBRANCH: 4.13
       SKIP_OCAML_TEST: no
     - OCAMLBRANCH: trunk
       SKIP_OCAML_TEST: no

--- a/appveyor_build.sh
+++ b/appveyor_build.sh
@@ -103,10 +103,11 @@ if [ ! -f $OCAMLROOT/STAMP ] || [ "$(git rev-parse HEAD)" != "$(cat $OCAMLROOT/S
         echo "Rebuilding the compiler"
     fi
 
+    rm -rf $OCAMLROOT
+
     configure_ocaml
 
     if [ ${OCAMLBRANCH/./} -lt 403 ] ; then
-      rm -rf $OCAMLROOT
       mkdir -p /cygdrive/c/flexdll
       mv "$APPVEYOR_BUILD_FOLDER/flexdll.zip" /cygdrive/c/flexdll
       pushd /cygdrive/c/flexdll


### PR DESCRIPTION
- trunk builds are failing at the moment because the installation directory isn't erased first
- 4.13 now tested (and so 4.11 is now only used to build the release artefacts)