### PR TITLE
Use /EMITVOLATILEMETADATA:NO with Microsoft Linker

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Next version
 - GPR#65: Support for compiling objects with /bigobj (Extended COFF) (Dmitry Bely)
 - GPR#80: Silence MSVC filenames for long commands as well as short ones (David Allsopp)
 - GPR#94: Fix parsing of COFF archives to ignore <XFGHASH> headers, allowing the Windows 11 SDK to be used. (David Allsopp)
+- GPR#96: Suppress volatile metadata on versions of MSVC which support it (David Allsopp)
 
 Version 0.39
 - GPR#89: Stop passing --image-base on Cygwin64 - Cygwin64 DLLs should load at

--- a/reloc.ml
+++ b/reloc.ml
@@ -1049,6 +1049,15 @@ let build_dll link_exe output_file files exts extra_args =
         let extra_args =
           if !machine = `x64 then (Printf.sprintf "/base:%s " !base_addr) ^ extra_args else extra_args
         in
+
+        let extra_args =
+          (* FlexDLL doesn't process .voltbl sections correctly, so don't allow the linker
+             to process them. *)
+          if Sys.command "link | findstr EMITVOLATILEMETADATA > nul" = 0 then
+            "/EMITVOLATILEMETADATA:NO " ^ extra_args
+          else extra_args
+        in
+
         (* Flexdll requires that all images (main programs and all the DLLs) are
            not too far away. This is needed because of the 32-bit relative relocations
            (e.g. function calls). It seems that passing such a /base argument to link.exe


### PR DESCRIPTION
Recent Visual Studio 2019 and 2022 are enabling volatile metadata on x64 by default. There don't appear to be many technical details available, but the purpose is to improve emulation of AMD64 on ARM64.
Sometimes the .voltbl sections are copying correctly and then seemingly minor code changes can break it, causing an obscure and undocumented error from the Microsoft Linker.

In parallel, OCaml will start to adding `/d2VolatileMetadata-` to its internal CFLAGS which should suppress the problem from both sides.